### PR TITLE
fix: add write permissions to auto-version workflow for GitHub Actions

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -12,6 +12,9 @@ jobs:
   version-bump:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, 'chore(release)')"
+    permissions:
+      contents: write
+      pull-requests: read
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
- Added contents: write permission to allow automated commits
- Added pull-requests: read permission for PR analysis
- Resolves GitHub Actions permission denied error when pushing version bumps