### PR TITLE
Fix tax calculation backend bug in pricesByLocation generation

### DIFF
--- a/app/Features/Tax.php
+++ b/app/Features/Tax.php
@@ -73,16 +73,24 @@ class Tax {
 				$final_regular_price = \wc_get_price_including_tax( $product, array( 'price' => $regular_price ) );
 				$final_sale_price    = \wc_get_price_including_tax( $product, array( 'price' => $sale_price ) );
 
-				$prices_by_location['with_tax']['locations'][]  = array( 'country' => $country, 'state' => $state );
-				$prices_by_location['with_tax']['regularPrice'] = (int) round( Woocommerce::format_price( $final_regular_price ) * 100 );
-				$prices_by_location['with_tax']['salePrice']    = (int) round( Woocommerce::format_price( $final_sale_price ) * 100 );
+				$prices_by_location['with_tax']['locations'][] = array( 'country' => $country, 'state' => $state );
+
+				// Only set prices if not already set, or if this is the first tax rate
+				if ( ! isset( $prices_by_location['with_tax']['regularPrice'] ) ) {
+					$prices_by_location['with_tax']['regularPrice'] = (int) round( Woocommerce::format_price( $final_regular_price ) * 100 );
+					$prices_by_location['with_tax']['salePrice']    = (int) round( Woocommerce::format_price( $final_sale_price ) * 100 );
+				}
 			} else {
 				$final_regular_price = \wc_get_price_excluding_tax( $product, array( 'price' => $regular_price ) );
 				$final_sale_price    = \wc_get_price_excluding_tax( $product, array( 'price' => $sale_price ) );
 
-				$prices_by_location['without_tax']['locations'][]  = array( 'country' => $country, 'state' => $state );
-				$prices_by_location['without_tax']['regularPrice'] = (int) round( Woocommerce::format_price( $final_regular_price ) * 100 );
-				$prices_by_location['without_tax']['salePrice']    = (int) round( Woocommerce::format_price( $final_sale_price ) * 100 );
+				$prices_by_location['without_tax']['locations'][] = array( 'country' => $country, 'state' => $state );
+
+				// Only set prices if not already set, or if this is the first tax rate
+				if ( ! isset( $prices_by_location['without_tax']['regularPrice'] ) ) {
+					$prices_by_location['without_tax']['regularPrice'] = (int) round( Woocommerce::format_price( $final_regular_price ) * 100 );
+					$prices_by_location['without_tax']['salePrice']    = (int) round( Woocommerce::format_price( $final_sale_price ) * 100 );
+				}
 			}
 		}
 


### PR DESCRIPTION
- Prevent overwriting of pricesByLocation prices in tax rate loop
- Only set prices on first tax rate to preserve sale price differences
- Resolves issue where regularPrice and salePrice had identical values
- Ensures proper sale price display in frontend components

This fixes the root cause where WordPress Tax.php was overwriting pricesByLocation data for each tax rate, causing both regular and sale prices to have the same value (e.g., both showing 4140 instead of 5520 vs 4140).

Related to WOOLESS-7521: Fix minicart price discrepancy between item and subtotal