### PR TITLE
Fix price NaN issue by changing data types from int64 to float

### DIFF
--- a/app/Collections/Product.php
+++ b/app/Collections/Product.php
@@ -53,9 +53,9 @@ class Product extends BaseCollection {
 
 		$currencies = Woocommerce::get_currencies();
 		foreach ( $currencies as $currency ) {
-			$price[] = array( 'name' => 'price.' . $currency, 'type' => 'int64', 'optional' => true, 'facet' => true );
-			$price[] = array( 'name' => 'regularPrice.' . $currency, 'type' => 'int64', 'optional' => true );
-			$price[] = array( 'name' => 'salePrice.' . $currency, 'type' => 'int64', 'optional' => true );
+			$price[] = array( 'name' => 'price.' . $currency, 'type' => 'float', 'optional' => true, 'facet' => true );
+			$price[] = array( 'name' => 'regularPrice.' . $currency, 'type' => 'float', 'optional' => true );
+			$price[] = array( 'name' => 'salePrice.' . $currency, 'type' => 'float', 'optional' => true );
 		}
 
 		return $price;
@@ -118,12 +118,12 @@ class Product extends BaseCollection {
 			array( 'name' => 'thumbnail.title', 'type' => 'string', 'optional' => true ),
 			array( 'name' => 'metaData', 'type' => 'object', 'optional' => true ),
 			array( 'name' => 'metaData.priceWithTax', 'type' => 'object', 'optional' => true ),
-			array( 'name' => 'metaData.priceWithTax.AUD', 'type' => 'int64', 'optional' => true ),
-			array( 'name' => 'metaData.priceWithTax.NZD', 'type' => 'int64', 'optional' => true ),
-			array( 'name' => 'metaData.priceWithTax.USD', 'type' => 'int64', 'optional' => true ),
-			array( 'name' => 'metaData.priceWithTax.GBP', 'type' => 'int64', 'optional' => true ),
-			array( 'name' => 'metaData.priceWithTax.CAD', 'type' => 'int64', 'optional' => true ),
-			array( 'name' => 'metaData.priceWithTax.EUR', 'type' => 'int64', 'optional' => true ),
+			array( 'name' => 'metaData.priceWithTax.AUD', 'type' => 'float', 'optional' => true ),
+			array( 'name' => 'metaData.priceWithTax.NZD', 'type' => 'float', 'optional' => true ),
+			array( 'name' => 'metaData.priceWithTax.USD', 'type' => 'float', 'optional' => true ),
+			array( 'name' => 'metaData.priceWithTax.GBP', 'type' => 'float', 'optional' => true ),
+			array( 'name' => 'metaData.priceWithTax.CAD', 'type' => 'float', 'optional' => true ),
+			array( 'name' => 'metaData.priceWithTax.EUR', 'type' => 'float', 'optional' => true ),
 			array( 'name' => 'metaData.productLabel', 'type' => 'string', 'optional' => true ),
 		);
 

--- a/app/Woocommerce.php
+++ b/app/Woocommerce.php
@@ -266,13 +266,12 @@ class Woocommerce {
 	}
 
 	/**
-	 * Use for making sure that we are setting a valid int type on prices so that typesense will accept it
-	 * Converts prices to cents (multiplied by 100) and returns as integer
-	 * Example: 6.76 becomes 676, 80.00 becomes 8000
+	 * Use for making sure that we are setting a valid float type on prices so that typesense will accept it
+	 * Formats prices as float values with 4 decimal places
+	 * Example: 6.76 becomes 6.7600, 80.00 becomes 80.0000
 	 */
 	public static function format_price( $price ) {
-		$formatted_price = (float) number_format( empty( $price ) ? 0 : $price, 4, '.', '' );
-		return (int) round( $formatted_price * 100 );
+		return (float) number_format( empty( $price ) ? 0 : $price, 4, '.', '' );
 	}
 
 	public static function get_currencies() {


### PR DESCRIPTION
## Problem

The frontend is displaying `NaN` for product prices due to a data type mismatch between the backend and frontend:

- **Backend**: Stores prices as `int64` (cents) - e.g., 19.99 becomes 1999
- **Frontend**: Expects `float` (decimal) values - e.g., 19.99

This mismatch causes mathematical operations in the frontend to fail, resulting in NaN values.

## Root Cause Analysis

After comparing the live server (working) vs staging server (broken):

**Live Server (Working):**
- Uses `'type' => 'float'` for price fields in Typesense schema
- `format_price()` returns float values

**Staging Server (Broken):**
- Uses `'type' => 'int64'` for price fields in Typesense schema  
- `format_price()` converts prices to cents and returns integers

## Solution

This PR fixes the issue by:

### 1. Updated Typesense Schema (`app/Collections/Product.php`)
- Changed price field types from `int64` to `float`:
  - `price.{currency}` fields
  - `regularPrice.{currency}` fields
  - `salePrice.{currency}` fields
  - `metaData.priceWithTax.{currency}` fields

### 2. Updated Price Formatting (`app/Woocommerce.php`)
- Modified `format_price()` method to return float values instead of converting to cents
- Updated method documentation to reflect the change

## Files Changed

- `app/Collections/Product.php`: Updated price schema fields
- `app/Woocommerce.php`: Updated format_price method and comments

## Testing

After this fix:
1. Products will need to be resynced to update Typesense with correct data types
2. Frontend should display proper decimal prices instead of NaN
3. Price calculations should work correctly

## Impact

- ✅ Fixes NaN price display issue
- ✅ Maintains compatibility with existing price logic
- ⚠️ Requires product resync after deployment

## Deployment Notes

After deploying this fix:
1. Run product sync to update Typesense collection with new data types
2. Verify prices display correctly in frontend
3. Test price calculations and cart functionality

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author