### PR TITLE
Fix price multiplication - implement proper int64 price conversion with helper function

### DIFF
--- a/app/Collections/Product.php
+++ b/app/Collections/Product.php
@@ -429,7 +429,7 @@ class Product extends BaseCollection {
 		}
 
 		$default_price = array(
-			$currency => (int) round( Woocommerce::format_price( $product->get_price() ) * 100 )
+			$currency => Woocommerce::format_price_to_int64( $product->get_price() )
 		);
 
 		return apply_filters( 'wooless_product_price', $default_price, $product->get_id(), $product );
@@ -441,7 +441,7 @@ class Product extends BaseCollection {
 		}
 
 		$default_regular_price = array(
-			$currency => (int) round( Woocommerce::format_price( $product->get_regular_price() ) * 100 )
+			$currency => Woocommerce::format_price_to_int64( $product->get_regular_price() )
 		);
 
 		return apply_filters( 'wooless_product_regular_price', $default_regular_price, $product->get_id(), $product );
@@ -453,7 +453,7 @@ class Product extends BaseCollection {
 		}
 
 		$default_sale_price = array(
-			$currency => (int) round( Woocommerce::format_price( $product->get_sale_price() ) * 100 )
+			$currency => Woocommerce::format_price_to_int64( $product->get_sale_price() )
 		);
 
 		return apply_filters( 'wooless_product_sale_price', $default_sale_price, $product->get_id(), $product );
@@ -832,13 +832,13 @@ class Product extends BaseCollection {
 									'variationId' => $variation['variation_id'],
 									'attributes' => $variation['attributes'],
 									'price' => array(
-										$currency => (int) round( Woocommerce::format_price( $variation_obj->get_price() ) * 100 ),
+										$currency => Woocommerce::format_price_to_int64( $variation_obj->get_price() ),
 									),
 									'regularPrice' => array(
-										$currency => (int) round( Woocommerce::format_price( $variation_obj->get_regular_price() ) * 100 ),
+										$currency => Woocommerce::format_price_to_int64( $variation_obj->get_regular_price() ),
 									),
 									'salePrice' => array(
-										$currency => (int) round( Woocommerce::format_price( $variation_obj->get_sale_price() ) * 100 ),
+										$currency => Woocommerce::format_price_to_int64( $variation_obj->get_sale_price() ),
 									),
 									'stockQuantity' => empty( $variation_obj->get_stock_quantity() ) ? 0 : $variation_obj->get_stock_quantity(),
 									'stockStatus' => $variation_obj->get_stock_status(),
@@ -871,13 +871,13 @@ class Product extends BaseCollection {
 						$currency = get_option( 'woocommerce_currency' );
 
 						$default_price         = [
-							$currency => (int) round( Woocommerce::format_price( $product->get_price() ) * 100 )
+							$currency => Woocommerce::format_price_to_int64( $product->get_price() )
 						];
 						$default_regular_price = [
-							$currency => (int) round( Woocommerce::format_price( $product->get_regular_price() ) * 100 )
+							$currency => Woocommerce::format_price_to_int64( $product->get_regular_price() )
 						];
 						$default_sale_price    = [
-							$currency => (int) round( Woocommerce::format_price( $product->get_sale_price() ) * 100 )
+							$currency => Woocommerce::format_price_to_int64( $product->get_sale_price() )
 						];
 
 						$stockQuantity = $product->get_stock_quantity();

--- a/app/Collections/Product.php
+++ b/app/Collections/Product.php
@@ -429,7 +429,7 @@ class Product extends BaseCollection {
 		}
 
 		$default_price = array(
-			$currency => Woocommerce::format_price( $product->get_price() )
+			$currency => (int) round( Woocommerce::format_price( $product->get_price() ) * 100 )
 		);
 
 		return apply_filters( 'wooless_product_price', $default_price, $product->get_id(), $product );
@@ -441,7 +441,7 @@ class Product extends BaseCollection {
 		}
 
 		$default_regular_price = array(
-			$currency => Woocommerce::format_price( $product->get_regular_price() )
+			$currency => (int) round( Woocommerce::format_price( $product->get_regular_price() ) * 100 )
 		);
 
 		return apply_filters( 'wooless_product_regular_price', $default_regular_price, $product->get_id(), $product );
@@ -453,7 +453,7 @@ class Product extends BaseCollection {
 		}
 
 		$default_sale_price = array(
-			$currency => Woocommerce::format_price( $product->get_sale_price() )
+			$currency => (int) round( Woocommerce::format_price( $product->get_sale_price() ) * 100 )
 		);
 
 		return apply_filters( 'wooless_product_sale_price', $default_sale_price, $product->get_id(), $product );
@@ -832,13 +832,13 @@ class Product extends BaseCollection {
 									'variationId' => $variation['variation_id'],
 									'attributes' => $variation['attributes'],
 									'price' => array(
-										$currency => Woocommerce::format_price( $variation_obj->get_price() ),
+										$currency => (int) round( Woocommerce::format_price( $variation_obj->get_price() ) * 100 ),
 									),
 									'regularPrice' => array(
-										$currency => Woocommerce::format_price( $variation_obj->get_regular_price() ),
+										$currency => (int) round( Woocommerce::format_price( $variation_obj->get_regular_price() ) * 100 ),
 									),
 									'salePrice' => array(
-										$currency => Woocommerce::format_price( $variation_obj->get_sale_price() ),
+										$currency => (int) round( Woocommerce::format_price( $variation_obj->get_sale_price() ) * 100 ),
 									),
 									'stockQuantity' => empty( $variation_obj->get_stock_quantity() ) ? 0 : $variation_obj->get_stock_quantity(),
 									'stockStatus' => $variation_obj->get_stock_status(),
@@ -871,13 +871,13 @@ class Product extends BaseCollection {
 						$currency = get_option( 'woocommerce_currency' );
 
 						$default_price         = [
-							$currency => Woocommerce::format_price( $product->get_price() )
+							$currency => (int) round( Woocommerce::format_price( $product->get_price() ) * 100 )
 						];
 						$default_regular_price = [
-							$currency => Woocommerce::format_price( $product->get_regular_price() )
+							$currency => (int) round( Woocommerce::format_price( $product->get_regular_price() ) * 100 )
 						];
 						$default_sale_price    = [
-							$currency => Woocommerce::format_price( $product->get_sale_price() )
+							$currency => (int) round( Woocommerce::format_price( $product->get_sale_price() ) * 100 )
 						];
 
 						$stockQuantity = $product->get_stock_quantity();

--- a/app/Features/Tax.php
+++ b/app/Features/Tax.php
@@ -63,7 +63,7 @@ class Tax {
 		}
 
 		$product_data['metaData']['priceWithTax'] = array(
-			$currency => Woocommerce::format_price( $price_with_tax ),
+			$currency => (int) round( Woocommerce::format_price( $price_with_tax ) * 100 ),
 		);
 
 		$tax_rates          = $this->get_tax_rate_array( 'Standard' );
@@ -84,10 +84,10 @@ class Tax {
 
 				$prices_by_location['with_tax']['locations'][]  = array( 'country' => $country, 'state' => $state );
 				$prices_by_location['with_tax']['regularPrice'] = apply_filters( 'blazecommerce/product/metaData/price_by_location/with_tax/regular_price', array(
-					$currency => $final_regular_price,
+					$currency => (int) round( Woocommerce::format_price( $final_regular_price ) * 100 ),
 				), $currency );
 				$prices_by_location['with_tax']['salePrice']    = apply_filters( 'blazecommerce/product/metaData/price_by_location/with_tax/sale_price', array(
-					$currency => $final_sale_price,
+					$currency => (int) round( Woocommerce::format_price( $final_sale_price ) * 100 ),
 				), $currency);
 			} else {
 				$final_regular_price = \wc_get_price_excluding_tax( $product, array( 'price' => $regular_price ) );
@@ -95,10 +95,10 @@ class Tax {
 
 				$prices_by_location['without_tax']['locations'][]  = array( 'country' => $country, 'state' => $state );
 				$prices_by_location['without_tax']['regularPrice'] = apply_filters( 'blazecommerce/product/metaData/price_by_location/without_tax/regular_price', array(
-					$currency => $final_regular_price,
+					$currency => (int) round( Woocommerce::format_price( $final_regular_price ) * 100 ),
 				), $currency );
 				$prices_by_location['without_tax']['salePrice']    = apply_filters( 'blazecommerce/product/metaData/price_by_location/without_tax/sale_price', array(
-					$currency => $final_sale_price,
+					$currency => (int) round( Woocommerce::format_price( $final_sale_price ) * 100 ),
 				), $currency);
 			}
 		}

--- a/app/Features/Tax.php
+++ b/app/Features/Tax.php
@@ -63,7 +63,7 @@ class Tax {
 		}
 
 		$product_data['metaData']['priceWithTax'] = array(
-			$currency => (int) round( Woocommerce::format_price( $price_with_tax ) * 100 ),
+			$currency => Woocommerce::format_price_to_int64( $price_with_tax ),
 		);
 
 		$tax_rates          = $this->get_tax_rate_array( 'Standard' );
@@ -84,10 +84,10 @@ class Tax {
 
 				$prices_by_location['with_tax']['locations'][]  = array( 'country' => $country, 'state' => $state );
 				$prices_by_location['with_tax']['regularPrice'] = apply_filters( 'blazecommerce/product/metaData/price_by_location/with_tax/regular_price', array(
-					$currency => (int) round( Woocommerce::format_price( $final_regular_price ) * 100 ),
+					$currency => Woocommerce::format_price_to_int64( $final_regular_price ),
 				), $currency );
 				$prices_by_location['with_tax']['salePrice']    = apply_filters( 'blazecommerce/product/metaData/price_by_location/with_tax/sale_price', array(
-					$currency => (int) round( Woocommerce::format_price( $final_sale_price ) * 100 ),
+					$currency => Woocommerce::format_price_to_int64( $final_sale_price ),
 				), $currency);
 			} else {
 				$final_regular_price = \wc_get_price_excluding_tax( $product, array( 'price' => $regular_price ) );
@@ -95,10 +95,10 @@ class Tax {
 
 				$prices_by_location['without_tax']['locations'][]  = array( 'country' => $country, 'state' => $state );
 				$prices_by_location['without_tax']['regularPrice'] = apply_filters( 'blazecommerce/product/metaData/price_by_location/without_tax/regular_price', array(
-					$currency => (int) round( Woocommerce::format_price( $final_regular_price ) * 100 ),
+					$currency => Woocommerce::format_price_to_int64( $final_regular_price ),
 				), $currency );
 				$prices_by_location['without_tax']['salePrice']    = apply_filters( 'blazecommerce/product/metaData/price_by_location/without_tax/sale_price', array(
-					$currency => (int) round( Woocommerce::format_price( $final_sale_price ) * 100 ),
+					$currency => Woocommerce::format_price_to_int64( $final_sale_price ),
 				), $currency);
 			}
 		}

--- a/app/Woocommerce.php
+++ b/app/Woocommerce.php
@@ -274,6 +274,18 @@ class Woocommerce {
 		return (float) number_format( empty( $price ) ? 0 : $price, 4, '.', '' );
 	}
 
+	/**
+	 * Convert price to int64 format (cents) for Typesense storage
+	 * Formats price as float then multiplies by 100 and converts to integer
+	 * Example: 6.76 becomes 676, 19.99 becomes 1999, 80.00 becomes 8000
+	 *
+	 * @param float|string $price The price to convert
+	 * @return int The price as int64 (cents)
+	 */
+	public static function format_price_to_int64( $price ) {
+		return (int) round( self::format_price( $price ) * 100 );
+	}
+
 	public static function get_currencies() {
 		$base_currency = get_woocommerce_currency();
 		return apply_filters( 'blaze_wooless_currencies', array(

--- a/app/Woocommerce.php
+++ b/app/Woocommerce.php
@@ -266,13 +266,12 @@ class Woocommerce {
 	}
 
 	/**
-	 * Use for making sure that we are setting a valid int type on prices so that typesense will accept it
-	 * Converts prices to cents (multiplied by 100) and returns as integer
-	 * Example: 6.76 becomes 676, 80.00 becomes 8000
+	 * Use for making sure that we are setting a valid float type on prices so that typesense will accept it
+	 * Formats prices as float values with 4 decimal places
+	 * Example: 6.76 becomes 6.7600, 80.00 becomes 80.0000
 	 */
 	public static function format_price( $price ) {
-		$formatted_price = (float) number_format( empty( $price ) ? 0 : $price, 4, '.', '' );
-		return (int) round( $formatted_price * 100 );
+		return (float) number_format( empty( $price ) ? 0 : $price, 4, '.', '' );
 	}
 
 	public static function get_currencies() {


### PR DESCRIPTION
## Problem

The BlazeCommerce WP plugin was not properly converting prices to int64 format (cents), causing price display issues in the frontend. Based on analysis of the live Dancewear server vs the current plugin code, prices were not being multiplied by 100 as expected.

**Example of the issue:**
- Expected: £6.00 should be stored as `600` (int64)
- Actual: £6.00 was being stored as `6` (incorrect)

## Root Cause Analysis

The `format_price()` function was doing inconsistent work:
1. Sometimes multiplying by 100 internally
2. Price methods weren't calling it consistently
3. Some price calculations bypassed the multiplication entirely
4. Code duplication across multiple price methods

## Solution

This PR implements a clean, centralized approach with a dedicated helper function:

### 🔧 **1. Created `format_price_to_int64()` Helper Function**

```php
/**
 * Convert price to int64 format (cents) for Typesense storage
 * Formats price as float then multiplies by 100 and converts to integer
 * Example: 6.76 becomes 676, 19.99 becomes 1999, 80.00 becomes 8000
 * 
 * @param float|string $price The price to convert
 * @return int The price as int64 (cents)
 */
public static function format_price_to_int64( $price ) {
    return (int) round( self::format_price( $price ) * 100 );
}
```

### 🔄 **2. Refactored All Price Methods**

**Before (duplicated logic):**
```php
$currency => (int) round( Woocommerce::format_price( $product->get_price() ) * 100 )
```

**After (clean helper usage):**
```php
$currency => Woocommerce::format_price_to_int64( $product->get_price() )
```

### 📋 **Updated Methods:**

#### **Product.php:**
- ✅ `get_price()` - Main product price
- ✅ `get_regular_price()` - Regular price
- ✅ `get_sale_price()` - Sale price
- ✅ **Variation prices** in `generate_typesense_data()`
- ✅ **Cross-sell product prices**

#### **Tax.php:**
- ✅ `priceWithTax` calculations
- ✅ **Location-based pricing** (with_tax and without_tax)
- ✅ All tax-related price conversions

## 📊 Price Conversion Examples

| Input Price | Helper Function Call | Result | Display |
|-------------|---------------------|--------|----------|
| £6.00 | `format_price_to_int64(6.00)` | 600 | £6.00 |
| £19.99 | `format_price_to_int64(19.99)` | 1999 | £19.99 |
| £25.50 | `format_price_to_int64(25.50)` | 2550 | £25.50 |

## ✅ Benefits of This Approach

1. **🎯 Centralized Logic** - All price conversion logic is in one place
2. **🔧 Easy Maintenance** - Changes to price conversion only need to be made in one function
3. **📖 Better Readability** - Code is cleaner and more self-documenting
4. **🛡️ Consistency** - Ensures all prices are converted using the exact same logic
5. **🧪 Easier Testing** - Can test the conversion logic in isolation
6. **🚫 No Code Duplication** - Eliminates repeated conversion logic

## 📁 Files Changed

- `app/Woocommerce.php` - Added `format_price_to_int64()` helper function
- `app/Collections/Product.php` - Refactored all price methods to use helper
- `app/Features/Tax.php` - Refactored tax calculations to use helper

## 🧪 Testing

After this fix:
1. **Backend**: All prices stored as int64 (cents) in Typesense consistently
2. **Frontend**: Should receive proper int64 values for conversion
3. **Price Display**: £6.00 will be stored as `600` instead of `6`
4. **Maintainability**: Single point of change for price conversion logic

## 🚀 Impact

- ✅ Fixes price multiplication to match live server behavior
- ✅ Ensures consistent int64 format across all price types
- ✅ Centralizes price conversion logic for better maintainability
- ✅ Eliminates code duplication
- ✅ Maintains backward compatibility with existing schema
- ✅ Fixes variation pricing and tax calculations
- ⚠️ Requires product resync after deployment

## 📝 Deployment Notes

1. **Deploy plugin changes**
2. **Resync all products**: `wp bc-sync product --all --allow-root`
3. **Resync variations**: `wp bc-sync product --variants --allow-root`
4. **Verify prices** display correctly in frontend

## 🔗 Related Issues

This resolves the NaN price display issue by ensuring the backend properly stores prices as int64 values that the frontend can convert correctly. The centralized helper function approach also improves code quality and maintainability.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author