### PR TITLE
fix: update Claude code review workflow permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     


### PR DESCRIPTION
Change pull-requests permission from 'read' to 'write' to allow Claude to comment on PRs Fixes workflow failure in PR 🎨 Comprehensive Color Testing Enhancements for Visual Testing Suite [large-pr] #133 where Claude couldn't post review comments Resolves GitHub Actions workflow run 16188685792 failure