### PR TITLE
fix: Force patch bump when version conflict occurs

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -162,6 +162,21 @@ jobs:
             ;;
         esac
 
+        # Check if new version equals current version and force patch bump if needed
+        if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
+          echo "⚠️  New version ($NEW_VERSION) equals current version ($CURRENT_VERSION)"
+          echo "🔄 Forcing patch version bump to resolve conflict..."
+
+          NEW_VERSION=$(node -e "
+            const semver = require('./scripts/semver-utils');
+            console.log(semver.incrementVersion('$CURRENT_VERSION', 'patch'));
+          ")
+
+          echo "📦 Forced new version: $NEW_VERSION"
+          echo "BUMP_TYPE=patch" >> $GITHUB_OUTPUT
+          echo "🚀 Updated bump type to: PATCH (forced due to version conflict)"
+        fi
+
         echo "📦 New version will be: $NEW_VERSION"
         echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Issue Description

The GitHub Actions auto-version workflow was failing due to a version conflict when the calculated new version equaled the current version (1.8.0). This occurred when commits didn't contain conventional commit messages that would trigger a version bump, causing the validation script to correctly reject the identical version.

## Root Cause

The workflow would:
1. Analyze commits for conventional commit patterns
2. Calculate a new version based on the patterns found
3. If no patterns were found or the calculated version equaled the current version, the validation would fail
4. This resulted in workflow failures with the error: `New version 1.8.0 is not greater than current version 1.8.0`

## Solution Implemented

Added logic to the auto-version workflow (`.github/workflows/auto-version.yml`) to:

1. **Detect version conflicts**: Check if the calculated new version equals the current version
2. **Auto-resolve conflicts**: Force a patch version increment when versions are identical
3. **Update workflow state**: Modify the `BUMP_TYPE` output to maintain consistency
4. **Provide transparency**: Log clear messages about when and why forced bumps occur

## Technical Details

### Changes Made

- **File**: `.github/workflows/auto-version.yml`
- **Location**: Added logic in the "Preview version bump" step after version calculation
- **Implementation**: Uses existing `semver-utils.js` utilities for consistency

### Code Added

```bash
# Check if new version equals current version and force patch bump if needed
if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
  echo "⚠️  New version ($NEW_VERSION) equals current version ($CURRENT_VERSION)"
  echo "🔄 Forcing patch version bump to resolve conflict..."
  
  NEW_VERSION=$(node -e "
    const semver = require('./scripts/semver-utils');
    console.log(semver.incrementVersion('$CURRENT_VERSION', 'patch'));
  ")
  
  echo "📦 Forced new version: $NEW_VERSION"
  echo "BUMP_TYPE=patch" >> $GITHUB_OUTPUT
  echo "🚀 Updated bump type to: PATCH (forced due to version conflict)"
fi
```

## Benefits

✅ **Prevents workflow failures** due to version conflicts  
✅ **Maintains semantic versioning** by ensuring versions always increment  
✅ **Provides clear feedback** about when and why forced patch bumps occur  
✅ **Uses existing utilities** for consistency with current codebase  
✅ **Minimal impact** - only affects the edge case where versions would be equal  

## Testing

- [x] Verified current version state (1.8.0 in all files)
- [x] Confirmed workflow logic handles the edge case
- [x] Ensured existing functionality remains unchanged
- [x] Validated semantic versioning compliance

## Success Criteria

After this fix, the auto-version workflow will:
1. ✅ Detect when the determined version equals the current version
2. ✅ Automatically increment the patch version in this case
3. ✅ Successfully complete the version bump process
4. ✅ Maintain workflow integrity and existing functionality

## Related

- Fixes the GitHub Actions workflow failure at: https://github.com/blaze-commerce/blazecommerce-wp-plugin/actions/runs/16213730687/job/45778511247
- Addresses version conflict edge cases in automated version management
- Improves CI/CD reliability for the BlazeCommerce WordPress plugin

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author