### PR TITLE
🔧 HOTFIX: Claude AI auto-approval string matching

### DIFF
--- a/.github/workflows/claude-auto-approval.yml
+++ b/.github/workflows/claude-auto-approval.yml
@@ -92,14 +92,17 @@ jobs:
               
               if (isClaudeBot && (comment.body.includes('FINAL VERDICT') || comment.body.includes('### FINAL VERDICT'))) {
                 console.log('Found Claude FINAL VERDICT comment from: ' + comment.user.login);
-                
-                if (comment.body.includes('Status: APPROVED')) {
+                console.log('Comment created at: ' + comment.created_at);
+                console.log('Comment excerpt: ' + comment.body.substring(comment.body.indexOf('FINAL VERDICT'), comment.body.indexOf('FINAL VERDICT') + 200));
+
+                // Check for status with flexible formatting (handles markdown bold)
+                if (comment.body.includes('Status**: APPROVED') || comment.body.includes('Status: APPROVED')) {
                   claudeApproval = 'APPROVED';
                   console.log('Claude status: APPROVED');
-                } else if (comment.body.includes('Status: BLOCKED')) {
+                } else if (comment.body.includes('Status**: BLOCKED') || comment.body.includes('Status: BLOCKED')) {
                   claudeApproval = 'BLOCKED';
                   console.log('Claude status: BLOCKED');
-                } else if (comment.body.includes('Status: CONDITIONAL')) {
+                } else if (comment.body.includes('Status**: CONDITIONAL') || comment.body.includes('Status: CONDITIONAL')) {
                   claudeApproval = 'CONDITIONAL';
                   console.log('Claude status: CONDITIONAL');
                 }


### PR DESCRIPTION
# 🔧 CRITICAL HOTFIX: Claude AI Auto-Approval String Matching

## 🎯 Root Cause Identified

**Issue**: Claude AI auto-approval workflow was failing to detect APPROVED status despite Claude posting correct FINAL VERDICT.

**Root Cause**: String matching mismatch between expected and actual format:
- **Workflow Expected**: `Status: APPROVED`
- **Claude Actual Format**: `**Status**: APPROVED` (with markdown bold asterisks)

## ✅ Solution Implemented

### String Detection Fix:
```javascript
// OLD (broken)
if (comment.body.includes('Status: APPROVED')) {

// NEW (fixed)
if (comment.body.includes('Status**: APPROVED') || comment.body.includes('Status: APPROVED')) {
```

### Enhanced Debug Logging:
- Comment creation timestamp
- Comment excerpt around FINAL VERDICT  
- User login verification
- Status detection confirmation

## 🧪 Testing Plan

1. **Merge this hotfix** to main branch
2. **Manual trigger test** on PR #357 (which has Claude APPROVED verdict)
3. **Verify auto-approval** occurs correctly
4. **Monitor debug logs** to confirm detection is working

## 🎉 Expected Result

After this fix:
- ✅ Claude's APPROVED verdicts will be correctly detected
- ✅ @blazecommerce-claude-ai will automatically approve PRs
- ✅ Auto-approval mechanism will be fully functional

---

**Priority**: CRITICAL - This fixes the core functionality of the Claude AI auto-approval system.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author