### PR TITLE
fix: correct spelling of initialize_default_home_page method name

### DIFF
--- a/app/PostType.php
+++ b/app/PostType.php
@@ -21,7 +21,7 @@ class PostType {
 
 
 
-	public static function initiliaze_default_home_page() {
+	public static function initialize_default_home_page() {
 		global $wpdb;
 
 		$post_name = 'blazecommerce-homepage';

--- a/blaze-wooless.php
+++ b/blaze-wooless.php
@@ -261,6 +261,6 @@ add_action( 'tgmpa_register', function () {
 
 function plugin_activate() {
 
-	PostType::initiliaze_default_home_page();
+	PostType::initialize_default_home_page();
 }
 register_activation_hook( __FILE__, 'plugin_activate' );


### PR DESCRIPTION
## Summary

This PR fixes a minor spelling error in the method name `initiliaze_default_home_page` which should be `initialize_default_home_page` (missing 'z').

## Changes Made

- Fixed method definition in `app/PostType.php` (line 24)
- Fixed method call in `blaze-wooless.php` (line 264)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the project's coding standards
- [x] Change is minimal and isolated
- [x] No functional changes, only spelling correction
- [x] Method is used internally within the plugin only

## Impact

- **Risk Level**: Very Low
- **Breaking Changes**: None
- **Backward Compatibility**: Maintained

## Version Bump Expected

This fix should trigger an automatic patch version bump from `1.14.1` to `1.14.2` when merged, as it uses the `fix:` commit prefix.

## Note

This is a test fix to verify the auto-versioning workflow. The change will be reverted later if needed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author