### PR TITLE
chore(release): bump version to 1.14.5 [patch]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The official plugin that integrates your WordPress/WooCommerce site with the Blaze Commerce service.
 
-**Version:** 1.14.1
+**Version:** 1.14.2
 **Author:** Blaze Commerce
 **Plugin URI:** https://www.blazecommerce.io
 **Author URI:** https://www.blazecommerce.io

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The official plugin that integrates your WordPress/WooCommerce site with the Blaze Commerce service.
 
-**Version:** 1.14.2
+**Version:** 1.14.5
 **Author:** Blaze Commerce
 **Plugin URI:** https://www.blazecommerce.io
 **Author URI:** https://www.blazecommerce.io

--- a/blaze-wooless.php
+++ b/blaze-wooless.php
@@ -3,7 +3,7 @@
 Plugin Name: Blaze Commerce
 Plugin URI: https://www.blazecommerce.io
 Description: The official plugin that integrates your site with the Blaze Commerce service.
-Version: 1.14.2
+Version: 1.14.5
 Requires Plugins: woocommerce, wp-graphql, wp-graphql-cors, wp-graphql-jwt-authentication, wp-graphql-woocommerce
 Author: Blaze Commerce
 Author URI: https://www.blazecommerce.io
@@ -13,7 +13,7 @@ use BlazeWooless\PostType;
 
 define( 'BLAZE_COMMERCE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BLAZE_COMMERCE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'BLAZE_COMMERCE_VERSION', '1.14.2' );
+define( 'BLAZE_COMMERCE_VERSION', '1.14.5' );
 
 require 'vendor/autoload.php';
 require_once plugin_dir_path( __FILE__ ) . 'lib/class-tgm-plugin-activation.php';

--- a/blaze-wooless.php
+++ b/blaze-wooless.php
@@ -3,7 +3,7 @@
 Plugin Name: Blaze Commerce
 Plugin URI: https://www.blazecommerce.io
 Description: The official plugin that integrates your site with the Blaze Commerce service.
-Version: 1.14.1
+Version: 1.14.2
 Requires Plugins: woocommerce, wp-graphql, wp-graphql-cors, wp-graphql-jwt-authentication, wp-graphql-woocommerce
 Author: Blaze Commerce
 Author URI: https://www.blazecommerce.io
@@ -13,7 +13,7 @@ use BlazeWooless\PostType;
 
 define( 'BLAZE_COMMERCE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BLAZE_COMMERCE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'BLAZE_COMMERCE_VERSION', '1.14.1' );
+define( 'BLAZE_COMMERCE_VERSION', '1.14.2' );
 
 require 'vendor/autoload.php';
 require_once plugin_dir_path( __FILE__ ) . 'lib/class-tgm-plugin-activation.php';

--- a/blocks/package.json
+++ b/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "author": "The WordPress Contributors",
   "license": "GPL-2.0-or-later",
   "main": "build/index.js",

--- a/blocks/package.json
+++ b/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location",
-  "version": "1.14.2",
+  "version": "1.14.5",
   "author": "The WordPress Contributors",
   "license": "GPL-2.0-or-later",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blazecommerce-wp-plugin",
-  "version": "1.14.2",
+  "version": "1.14.5",
   "description": "The official plugin that integrates your site with the Blaze Commerce service.",
   "main": "blaze-wooless.php",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blazecommerce-wp-plugin",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "The official plugin that integrates your site with the Blaze Commerce service.",
   "main": "blaze-wooless.php",
   "scripts": {
@@ -35,7 +35,6 @@
     "test:validation-flags": "node scripts/test-validation-flags.js",
     "test:version-fix": "node scripts/test-version-fix.js",
     "test:comprehensive-version": "node scripts/test-comprehensive-version-system.js",
-
     "test:integration-version": "node scripts/test-integration-version-system.js",
     "test:workflow-fixes": "node scripts/test-workflow-fixes.js",
     "test:dependencies": "bash scripts/test-dependencies.sh",


### PR DESCRIPTION
🤖 **Automated Version Bump**

This PR completes the version bump that failed in the GitHub Actions workflow due to branch protection rules.

## Changes Made
- Updated package.json: 1.14.2 → 1.14.5
- Updated blaze-wooless.php version header and constant
- Updated README.md version badge
- Updated blocks/package.json version

## Context
- **Triggered by**: PR #370 (fix: correct spelling of initialize_default_home_page method name)
- **Original workflow failure**: Auto-version workflow couldn't push directly to main
- **Resolution**: Manual version bump with next available version (1.14.5)

## Files Updated
- `package.json`
- `blaze-wooless.php`
- `README.md`
- `blocks/package.json`

## Auto-Merge Safe
This PR only contains version number updates and can be safely merged.

**Tag created**: v1.14.5 (will be pushed after merge)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author