### PR TITLE
Fix GitHub App workflow validation errors

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -147,7 +147,10 @@ jobs:
     steps:
     - name: Generate GitHub App Token
       id: app_token
-      if: secrets.BC_GITHUB_APP_ID && secrets.BC_GITHUB_APP_PRIVATE_KEY
+      if: env.BC_GITHUB_APP_ID != '' && env.BC_GITHUB_APP_PRIVATE_KEY != ''
+      env:
+        BC_GITHUB_APP_ID: ${{ secrets.BC_GITHUB_APP_ID }}
+        BC_GITHUB_APP_PRIVATE_KEY: ${{ secrets.BC_GITHUB_APP_PRIVATE_KEY }}
       uses: actions/create-github-app-token@v1
       with:
         app-id: ${{ secrets.BC_GITHUB_APP_ID }}

--- a/.github/workflows/claude-auto-approval.yml
+++ b/.github/workflows/claude-auto-approval.yml
@@ -25,7 +25,10 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app_token
-        if: secrets.BC_GITHUB_APP_ID && secrets.BC_GITHUB_APP_PRIVATE_KEY
+        if: env.BC_GITHUB_APP_ID != '' && env.BC_GITHUB_APP_PRIVATE_KEY != ''
+        env:
+          BC_GITHUB_APP_ID: ${{ secrets.BC_GITHUB_APP_ID }}
+          BC_GITHUB_APP_PRIVATE_KEY: ${{ secrets.BC_GITHUB_APP_PRIVATE_KEY }}
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.BC_GITHUB_APP_ID }}


### PR DESCRIPTION
## Problem

Two GitHub workflow files were experiencing validation errors due to incorrect usage of the `secrets` context in conditional expressions:

1. `.github/workflows/claude-auto-approval.yml` (line 28)
2. `.github/workflows/auto-version.yml` (line 150)

**Error Message:**
```
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.BC_GITHUB_APP_ID && secrets.BC_GITHUB_APP_PRIVATE_KEY
```

**Failed Workflow Runs:**
- Claude Auto-Approval: https://github.com/blaze-commerce/blazecommerce-wp-plugin/actions/runs/16270217686
- Auto-Version: https://github.com/blaze-commerce/blazecommerce-wp-plugin/actions/runs/16270159973

## Root Cause

GitHub Actions does not allow direct access to the `secrets` context in `if` conditional expressions. The syntax:
```yaml
if: secrets.BC_GITHUB_APP_ID && secrets.BC_GITHUB_APP_PRIVATE_KEY
```
is invalid and causes validation failures.

## Solution

Replaced direct secrets references with environment variables in the conditional checks:

**Before:**
```yaml
if: secrets.BC_GITHUB_APP_ID && secrets.BC_GITHUB_APP_PRIVATE_KEY
```

**After:**
```yaml
if: env.BC_GITHUB_APP_ID != '' && env.BC_GITHUB_APP_PRIVATE_KEY != ''
env:
  BC_GITHUB_APP_ID: ${{ secrets.BC_GITHUB_APP_ID }}
  BC_GITHUB_APP_PRIVATE_KEY: ${{ secrets.BC_GITHUB_APP_PRIVATE_KEY }}
```

## Changes Made

### 1. `.github/workflows/claude-auto-approval.yml`
- Fixed line 28: Replaced direct secrets reference with environment variable check
- Added `env` block to expose secrets as environment variables for the conditional
- Maintained original secrets usage in the `with` block for the GitHub App token generation

### 2. `.github/workflows/auto-version.yml`
- Fixed line 150: Applied the same environment variable approach
- Preserved all existing functionality and fallback authentication logic

## Benefits

✅ **Resolves Validation Errors**: Workflows will now pass GitHub Actions validation
✅ **Maintains Functionality**: GitHub App authentication continues to work as intended
✅ **Preserves Fallback Logic**: Workflows still fall back to `BOT_GITHUB_TOKEN` or `github.token` when GitHub App secrets are unavailable
✅ **No Breaking Changes**: All existing behavior is preserved

## Testing

After merging this PR:
1. The workflows should pass validation without errors
2. GitHub App authentication should continue working with the configured secrets
3. Fallback authentication mechanisms remain intact
4. Both auto-approval and auto-versioning functionality should work as expected

## GitHub App Configuration

The GitHub App (blazecommerce-automation-bot) has been properly configured with:
- Organization-level permissions at https://github.com/organizations/blaze-commerce/settings/apps/blazecommerce-automation-bot
- Required secrets: `BC_GITHUB_APP_ID` and `BC_GITHUB_APP_PRIVATE_KEY`
- Appropriate repository access and permissions

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author