### PR TITLE
fix(workflows): resolve paths/paths-ignore conflict in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,16 +4,6 @@ name: "Priority 2: Claude AI Code Review"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - '**.php'
-      - '**.js'
-      - '**.ts'
-      - '**.jsx'
-      - '**.tsx'
-      - 'src/**'
-      - 'includes/**'
-      - 'lib/**'
-      - 'assets/**'
     paths-ignore:
       - 'docs/**'
       - '**.md'


### PR DESCRIPTION
## Description
This PR fixes the GitHub Actions workflow error in the Claude code review workflow.

### Issue
The workflow was failing with the error: "Invalid workflow file: you may only define one of `paths` and `paths-ignore` for a single event"

### Root Cause
The workflow had both `paths` and `paths-ignore` defined for the same `pull_request` event, which is not allowed by GitHub Actions.

### Solution
- Removed the `paths` section that was specifying which files should trigger the workflow
- Kept only the `paths-ignore` section that specifies which files should NOT trigger the workflow

This maintains the intended behavior of the workflow (running on code changes but skipping documentation and test files) while fixing the validation error.

### Changes
- Modified `.github/workflows/claude-code-review.yml` to use only `paths-ignore`

### References
- Failing workflow run: https://github.com/blaze-commerce/blazecommerce-wp-plugin/actions/runs/16287397346/workflow

### Testing
The workflow should now pass validation and run successfully on pull requests that modify files not in the `paths-ignore` list.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author