### PR TITLE
fix(workflows): correct Claude model names to valid current identifiers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -153,7 +153,7 @@ jobs:
             // Force Sonnet if requested via workflow_dispatch
             if (forceSonnet) {
               console.log('🔧 MANUAL OVERRIDE: Force Sonnet requested');
-              core.setOutput('model', 'claude-3-sonnet-20240229');
+              core.setOutput('model', 'claude-3-5-sonnet-20241022');
               core.setOutput('reason', 'Manual override via workflow_dispatch');
               return;
             }
@@ -201,15 +201,15 @@ jobs:
               let model, reason;
 
               if (hasCriticalFiles) {
-                model = 'claude-3-sonnet-20240229';
+                model = 'claude-3-5-sonnet-20241022';
                 reason = 'Critical security/auth/payment files detected';
                 console.log('🔴 SONNET SELECTED: Critical files found');
               } else if (totalChanges > 200) {
-                model = 'claude-3-sonnet-20240229';
+                model = 'claude-3-5-sonnet-20241022';
                 reason = `Large changeset (${totalChanges} changes > 200 threshold)`;
                 console.log('🔴 SONNET SELECTED: Large changeset');
               } else if (totalChanges > 100 && changedFiles.some(f => f.endsWith('.php'))) {
-                model = 'claude-3-sonnet-20240229';
+                model = 'claude-3-5-sonnet-20241022';
                 reason = `Medium PHP changeset (${totalChanges} changes)`;
                 console.log('🟡 SONNET SELECTED: Medium PHP changes');
               } else {


### PR DESCRIPTION
## Description
This PR fixes the GitHub Actions workflow error by correcting the Claude model names to use valid current identifiers.

### Issue
The workflow was failing at step 6 "Run Claude Code Review" due to invalid model names being passed to the `anthropics/claude-code-action@beta` action.

### Root Cause
In the previous fix (PR #416), I incorrectly changed the Claude 3.5 Sonnet model name from `claude-3-5-sonnet-20241022` to `claude-3-sonnet-20240229`. However, `claude-3-sonnet-20240229` doesn't exist in Anthropic's model lineup.

### Solution
- **Reverted Sonnet model**: Changed back from `claude-3-sonnet-20240229` to `claude-3-5-sonnet-20241022` (correct current version)
- **Kept Haiku model**: `claude-3-haiku-20240307` was already correct
- **Verified against official documentation**: Used Anthropic's current model documentation to confirm valid model names

### Changes
- Modified `.github/workflows/claude-code-review.yml`:
  - Line 156: Restored correct Sonnet model name for manual override
  - Lines 204, 208, 212: Restored correct Sonnet model name in automatic selection logic

### Model Names (Current & Valid)
Based on [Anthropic's official model documentation](https://docs.anthropic.com/en/docs/about-claude/models/overview):
- ✅ **Claude 3.5 Sonnet**: `claude-3-5-sonnet-20241022` (current version)
- ✅ **Claude 3 Haiku**: `claude-3-haiku-20240307` (current version)
- ❌ **Invalid**: `claude-3-sonnet-20240229` (doesn't exist)

### References
- Failing workflow run: https://github.com/blaze-commerce/blazecommerce-wp-plugin/actions/runs/16288218453/job/45991692559#step:6:735
- Previous fix attempt: PR #416
- Anthropic model documentation: https://docs.anthropic.com/en/docs/about-claude/models/overview

### Testing
The workflow should now:
1. ✅ Pass model validation in the Claude Code Action
2. ✅ Successfully execute code reviews
3. ✅ Maintain intelligent model selection logic
4. ✅ Continue working with cost optimization features

### Impact
- Fixes the failing Claude code review workflow
- Restores the original working model configuration
- Maintains all existing workflow functionality
- No breaking changes to triggers or behavior

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author