### PR TITLE
test: verify Claude workflow fix for OWNER/COLLABORATOR associations

### DIFF
--- a/TEST-CLAUDE-WORKFLOW-FIX.md
+++ b/TEST-CLAUDE-WORKFLOW-FIX.md
@@ -1,0 +1,35 @@
+# Claude Workflow Fix Verification
+
+This is a test file to verify that the Claude code review workflow now works correctly.
+
+## What Was Fixed
+
+The workflow was failing because it had a condition that only allowed:
+- `FIRST_TIME_CONTRIBUTOR`
+- `CONTRIBUTOR` 
+- PRs with specific labels
+
+But repository owners and collaborators have `OWNER` or `COLLABORATOR` associations, so the workflow was being skipped entirely.
+
+## The Fix
+
+Added `COLLABORATOR` and `OWNER` to the workflow conditions:
+
+```yaml
+if: |
+  github.event_name == 'workflow_dispatch' ||
+  github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+  github.event.pull_request.author_association == 'CONTRIBUTOR' ||
+  github.event.pull_request.author_association == 'COLLABORATOR' ||
+  github.event.pull_request.author_association == 'OWNER' ||
+  contains(github.event.pull_request.labels.*.name, 'needs-review') ||
+  contains(github.event.pull_request.labels.*.name, 'external-review')
+```
+
+## Expected Result
+
+This PR should now trigger the Claude code review workflow and it should run successfully with:
+- Model: `claude-3-5-sonnet-20241022`
+- Action: `anthropics/claude-code-action@beta`
+
+If this works, the Claude workflow is finally fixed! 🎉


### PR DESCRIPTION
## 🧪 **Test PR: Claude Workflow Fix Verification**

### **Purpose**
This PR tests whether the Claude code review workflow now works correctly after fixing the author association conditions.

### **What Was Broken**
The workflow had this condition:
```yaml
if: |
  github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
  github.event.pull_request.author_association == 'CONTRIBUTOR' ||
  # ... other conditions
```

**Problem:** Repository owners and collaborators have `OWNER` or `COLLABORATOR` associations, so the workflow was being **completely skipped**.

### **The Fix Applied**
Added `COLLABORATOR` and `OWNER` to the workflow execution conditions:
```yaml
if: |
  github.event_name == 'workflow_dispatch' ||
  github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
  github.event.pull_request.author_association == 'CONTRIBUTOR' ||
  github.event.pull_request.author_association == 'COLLABORATOR' ||  # ✅ ADDED
  github.event.pull_request.author_association == 'OWNER' ||         # ✅ ADDED
  contains(github.event.pull_request.labels.*.name, 'needs-review') ||
  contains(github.event.pull_request.labels.*.name, 'external-review')
```

### **Expected Result**
- ✅ **Workflow should trigger** (not skip like before)
- ✅ **Should use updated model:** `claude-3-5-sonnet-20241022`
- ✅ **Should use updated action:** `anthropics/claude-code-action@beta`
- ✅ **Should complete successfully** with Claude code review

### **If This Works**
🎉 **The Claude workflow is finally fixed!** All future PRs from repository owners/collaborators will get Claude code reviews.

---

**This is the root cause fix for why ALL previous attempts failed - the workflow wasn't running at all!**

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author