### PR TITLE
fix: sync version files to match existing v1.15.0 tag

### DIFF
--- a/blaze-wooless.php
+++ b/blaze-wooless.php
@@ -3,7 +3,7 @@
 Plugin Name: Blaze Commerce
 Plugin URI: https://www.blazecommerce.io
 Description: The official plugin that integrates your site with the Blaze Commerce service.
-Version: 1.14.5
+Version: 1.15.0
 Requires Plugins: woocommerce, wp-graphql, wp-graphql-cors, wp-graphql-jwt-authentication, wp-graphql-woocommerce
 Author: Blaze Commerce
 Author URI: https://www.blazecommerce.io
@@ -13,7 +13,7 @@ use BlazeWooless\PostType;
 
 define( 'BLAZE_COMMERCE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BLAZE_COMMERCE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'BLAZE_COMMERCE_VERSION', '1.14.5' );
+define( 'BLAZE_COMMERCE_VERSION', '1.15.0' );
 
 require 'vendor/autoload.php';
 require_once plugin_dir_path( __FILE__ ) . 'lib/class-tgm-plugin-activation.php';

--- a/blocks/package.json
+++ b/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location",
-  "version": "1.14.5",
+  "version": "1.15.0",
   "author": "The WordPress Contributors",
   "license": "GPL-2.0-or-later",
   "main": "build/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blazecommerce-wp-plugin",
-  "version": "1.14.5",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blazecommerce-wp-plugin",
-      "version": "1.14.5",
+      "version": "1.15.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@octokit/auth-app": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blazecommerce-wp-plugin",
-  "version": "1.14.5",
+  "version": "1.15.0",
   "description": "The official plugin that integrates your site with the Blaze Commerce service.",
   "main": "blaze-wooless.php",
   "scripts": {


### PR DESCRIPTION
## 🚨 **Critical Fix: Version Mismatch Resolution**

### **Problem**
- Git tag `v1.15.0` already exists and points to current HEAD commit
- Version files in code still show `1.14.5` (package.json, blaze-wooless.php, blocks/package.json)
- Auto-version workflow failing with "Git tag v1.15.0 already exists" error

### **Root Cause**
A previous workflow run successfully created the `v1.15.0` tag, but the version files were never updated to reflect this change, causing a mismatch between the git tag and the code version.

### **Solution Applied**
✅ **Updated all version files to match existing v1.15.0 tag:**
- `package.json`: 1.14.5 → 1.15.0
- `blaze-wooless.php` plugin header: 1.14.5 → 1.15.0  
- `blaze-wooless.php` BLAZE_COMMERCE_VERSION constant: 1.14.5 → 1.15.0
- `blocks/package.json`: 1.14.5 → 1.15.0
- Regenerated `package-lock.json` to reflect version changes

### **Impact**
- 🔧 **Fixes auto-version workflow** that was failing due to tag conflicts
- ⚡ **Enables future version bumps** to work correctly
- 📊 **Resolves GitHub Actions workflow run #16301623909** version bump failure
- 🛡️ **Maintains version consistency** across all plugin files

### **Testing**
- [x] All version files now show 1.15.0
- [x] package-lock.json regenerated successfully
- [x] No breaking changes to plugin functionality
- [x] Ready for next version bump (will be 1.15.1 or 1.16.0)

### **Next Steps**
After this PR is merged:
1. Future version bump workflows will work correctly
2. Next version will be 1.15.1 (patch) or 1.16.0 (minor) depending on changes
3. No manual intervention needed for version management

**Resolves:** Auto-version workflow failures due to tag/version mismatch  
**Fixes:** GitHub Actions run #16301623909 "Git tag v1.15.0 already exists" error

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author